### PR TITLE
fix: ⬆️ Change iscoroutinefunction calls from asyncio to inspect

### DIFF
--- a/src/metrics_python/django/middleware.py
+++ b/src/metrics_python/django/middleware.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import inspect
 import time
 from contextvars import ContextVar
 from functools import wraps
@@ -90,7 +91,7 @@ def observe_metrics(
 def MetricsMiddleware(
     get_response: MIDDLEWARE | ASYNC_MIDDLEWARE,
 ) -> MIDDLEWARE | ASYNC_MIDDLEWARE:
-    if asyncio.iscoroutinefunction(get_response):
+    if inspect.iscoroutinefunction(get_response):
 
         async def async_middleware(request: HttpRequest) -> HttpResponse:
             request_start_time = time.perf_counter()
@@ -158,7 +159,7 @@ def _measure_request(
 def QueryCountMiddleware(
     get_response: MIDDLEWARE | ASYNC_MIDDLEWARE,
 ) -> MIDDLEWARE | ASYNC_MIDDLEWARE:
-    if asyncio.iscoroutinefunction(get_response):
+    if inspect.iscoroutinefunction(get_response):
 
         async def async_middleware(request: HttpRequest) -> HttpResponse:
             with QueryCounter.create_counter() as counter:
@@ -302,7 +303,7 @@ def _wrap_middleware(middleware: Any, middleware_name: str) -> Any:  # noqa
             with _get_response_timer():
                 return await get_response(*args, **kwargs)
 
-        if asyncio.iscoroutinefunction(get_response):
+        if inspect.iscoroutinefunction(get_response):
             return wraps(get_response)(_aget_response)
 
         return wraps(get_response)(_get_response)
@@ -329,11 +330,11 @@ def _wrap_middleware(middleware: Any, middleware_name: str) -> Any:  # noqa
                 self._async_check()
 
         def _async_check(self) -> None:
-            if asyncio.iscoroutinefunction(self.get_response):
+            if inspect.iscoroutinefunction(self.get_response):
                 self._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore
 
         def async_route_check(self) -> bool:
-            return asyncio.iscoroutinefunction(self.get_response)
+            return inspect.iscoroutinefunction(self.get_response)
 
         def __getattr__(self, method_name: str) -> Any:
             if method_name not in (


### PR DESCRIPTION
Getting this warning before this patch:

```
/path/to/project/.venv/lib/python3.14/site-packages/metrics_python/django/middleware.py:305:
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and
slated for removal in Python 3.16; use inspect.iscoroutinefunction()
instead
```

So doing something like this sounds like a good idea at least before Python 3.16 😄

(didn't wanna mess with poetry, so I haven't linted, tested, or anything)